### PR TITLE
add hook to remove invoice filter sidebar

### DIFF
--- a/includes/hooks/paypalbilling.php
+++ b/includes/hooks/paypalbilling.php
@@ -54,3 +54,16 @@ add_hook('AdminAreaClientSummaryPage', 10, function($vars) {
 
     return $output;
 });
+
+add_hook('ClientAreaPrimarySidebar', 1, function(MenuItem $primarySidebar)
+{
+
+   $filename = APP::getCurrentFileName();
+   $action = $_GET['action'];
+
+
+   if ($filename=='paypalbilling' && $action=='manage' && !is_null($primarySidebar->getChild('My Invoices Status Filter'))) {
+                   $primarySidebar->removeChild('My Invoices Status Filter');
+       }
+
+});


### PR DESCRIPTION
Added a hook to remove the invoice filter in the sidebar of the PayPal Billing page. The filter isn't needed and is confusing when they are no invoices listed on the page.